### PR TITLE
Writing more EXIF into output TIFF

### DIFF
--- a/src/raw_alchemy/core.py
+++ b/src/raw_alchemy/core.py
@@ -38,8 +38,8 @@ def process_image(
     # --- Step 1: 解码 RAW (统一至 ProPhoto RGB / 16-bit Linear) ---
     logger.info(f"  🔹 [Step 1] Decoding RAW...")
     with rawpy.imread(raw_path) as raw:
-        # 提取 EXIF (用于镜头校正)
-        exif_data = utils.extract_lens_exif(raw, logger=logger.log)
+        # 提取 EXIF (用于镜头校正和元数据保存)
+        exif_data = utils.extract_lens_exif(raw, logger=logger.log, raw_path=raw_path)
 
         # 解码: 必须使用 16-bit 以保留 Log 转换所需的动态范围
         prophoto_linear = raw.postprocess(
@@ -137,8 +137,10 @@ def process_image(
 
     # --- Step 6: 保存（使用模块化的文件保存功能）---
     logger.info(f"  💾 Saving to {os.path.basename(output_path)}...")
-    save_image(img, output_path, logger)
+    save_image(img, output_path, logger, exif_data=exif_data)
     
     # --- 最终清理 ---
     del img
     gc.collect()
+    
+    return True

--- a/src/raw_alchemy/file_io.py
+++ b/src/raw_alchemy/file_io.py
@@ -7,13 +7,14 @@ import numpy as np
 import tifffile
 from PIL import Image
 import pillow_heif
-from typing import Optional
+from typing import Optional, Dict, Any
 from raw_alchemy.logger import Logger
 
 def save_image(
     img: np.ndarray,
     output_path: str,
-    logger: Optional[Logger] = None
+    logger: Optional[Logger] = None,
+    exif_data: Optional[Dict[str, Any]] = None
 ) -> bool:
     """
     保存图像到指定路径，根据扩展名自动选择格式
@@ -22,6 +23,7 @@ def save_image(
         img: 图像数据 (float32, 0.0-1.0)
         output_path: 输出路径
         logger: 日志处理器
+        exif_data:可选的EXIF数据字典
     
     Returns:
         bool: 是否保存成功
@@ -37,11 +39,11 @@ def save_image(
     
     try:
         if file_ext in ['.tif', '.tiff']:
-            _save_tiff(img, output_path, logger)
+            _save_tiff(img, output_path, logger, exif_data)
         elif file_ext in ['.heic', '.heif']:
-            _save_heif(img, output_path, logger)
+            _save_heif(img, output_path, logger, exif_data)
         else:
-            _save_jpeg_or_other(img, output_path, file_ext, logger)
+            _save_jpeg_or_other(img, output_path, file_ext, logger, exif_data)
         
         logger.info(f"  ✅ Saved: {output_path}")
         return True
@@ -53,8 +55,8 @@ def save_image(
         return False
 
 
-def _save_tiff(img: np.ndarray, output_path: str, logger: Logger):
-    """保存为 16-bit TIFF 格式"""
+def _save_tiff(img: np.ndarray, output_path: str, logger: Logger, exif_data: Optional[Dict[str, Any]] = None):
+    """保存为 16-bit TIFF 格式并通过 pyexiv2写入EXIF信息"""
     logger.info("    Format: TIFF (16-bit, ZLIB Optimized)")
     output_image_uint16 = (img * 65535).astype(np.uint16)
     
@@ -63,12 +65,158 @@ def _save_tiff(img: np.ndarray, output_path: str, logger: Logger):
         output_image_uint16,
         photometric='rgb',
         compression='zlib',
-        predictor=2,  # 水平差分，提升压缩率
-        compressionargs={'level': 8}  # 平衡速度和体积
+        predictor=2,    # 水平差分，提升压缩率
+        compressionargs={'level': 8}    # 平衡速度和体积
     )
+    
+    # Add EXIF if data is provided
+    if exif_data and len(exif_data) > 0:
+        logger.info(f"    📍 Embedding EXIF data: {', '.join(exif_data.keys())}")
+        _add_exif_with_pyexiv2(output_path, exif_data, logger)
 
 
-def _save_heif(img: np.ndarray, output_path: str, logger: Logger):
+def _add_exif_with_pyexiv2(tiff_path: str, exif_data: Dict[str, Any], logger: Logger):
+    """Add EXIF data to TIFF file using pyexiv2"""
+    try:
+        import pyexiv2
+        
+        # Open image and read current EXIF
+        image = pyexiv2.Image(tiff_path)
+        
+        # Build EXIF dictionary
+        exif_dict = {}
+        
+        # 0th IFD / Image tags
+        if 'camera_maker' in exif_data:
+            exif_dict['Exif.Image.Make'] = exif_data['camera_maker']
+        
+        if 'camera_model' in exif_data:
+            exif_dict['Exif.Image.Model'] = exif_data['camera_model']
+        
+        if 'timestamp' in exif_data:
+            exif_dict['Exif.Image.DateTime'] = exif_data['timestamp']
+            # Also add to Photo SubIFD as DateTimeOriginal and DateTimeDigitized
+            exif_dict['Exif.Photo.DateTimeOriginal'] = exif_data['timestamp']
+            exif_dict['Exif.Photo.DateTimeDigitized'] = exif_data['timestamp']
+        
+        # Photo tags (Exif SubIFD)
+        if 'iso' in exif_data:
+            exif_dict['Exif.Photo.ISOSpeedRatings'] = str(int(exif_data['iso']))
+        
+        if 'focal_length' in exif_data:
+            try:
+                focal = float(exif_data['focal_length'])
+                exif_dict['Exif.Photo.FocalLength'] = f"{int(focal * 10)}/10"
+            except (ValueError, TypeError):
+                pass
+        
+        if 'shutter_speed' in exif_data:
+            try:
+                shutter = float(exif_data['shutter_speed'])
+                # shutter_speed is stored as the fraction value (e.g., 0.025 = 1/40)
+                # Convert to proper fraction notation "1/denominator"
+                if shutter > 0:
+                    exif_dict['Exif.Photo.ExposureTime'] = f"1/{int(1/shutter)}"
+                else:
+                    exif_dict['Exif.Photo.ExposureTime'] = f"{int(shutter)}/1"
+            except (ValueError, TypeError, ZeroDivisionError):
+                pass
+        
+        if 'aperture' in exif_data:
+            try:
+                aperture = float(exif_data['aperture'])
+                # FNumber should be stored as a fraction
+                exif_dict['Exif.Photo.FNumber'] = f"{int(aperture * 10)}/10"
+            except (ValueError, TypeError):
+                pass
+        
+        if 'lens_model' in exif_data:
+            exif_dict['Exif.Photo.LensModel'] = exif_data['lens_model']
+        
+        if 'exposure_bias' in exif_data:
+            try:
+                bias = float(exif_data['exposure_bias'])
+                exif_dict['Exif.Photo.ExposureBiasValue'] = f"{int(bias * 10)}/10"
+            except (ValueError, TypeError):
+                pass
+        
+        if 'metering_mode' in exif_data:
+            try:
+                metering = int(exif_data['metering_mode'])
+                exif_dict['Exif.Photo.MeteringMode'] = str(metering)
+            except (ValueError, TypeError):
+                pass
+        
+        if 'flash' in exif_data:
+            try:
+                flash = int(exif_data['flash'])
+                exif_dict['Exif.Photo.Flash'] = str(flash)
+            except (ValueError, TypeError):
+                pass
+        
+        if 'exposure_program' in exif_data:
+            try:
+                exposure_program = int(exif_data['exposure_program'])
+                exif_dict['Exif.Photo.ExposureProgram'] = str(exposure_program)
+            except (ValueError, TypeError):
+                pass
+        
+        # Add software tag
+        exif_dict['Exif.Image.Software'] = 'Raw Alchemy'
+        
+        # Write EXIF data
+        image.modify_exif(exif_dict)
+        image.close()
+        
+        logger.info(f"    ✅ EXIF data embedded successfully")
+        
+    except ImportError:
+        logger.warning(f"    ⚠️  pyexiv2 not available, EXIF not embedded")
+    except Exception as e:
+        logger.warning(f"    ⚠️  Failed to add EXIF with pyexiv2: {e}")
+
+
+def _create_exif_text_summary(exif_data: Dict[str, Any]) -> str:
+    """
+    创建 EXIF 数据的文本摘要，可以存储在 TIFF 的 ImageDescription 标签中。
+    
+    Args:
+        exif_data: EXIF 数据字典
+    
+    Returns:
+        EXIF 数据的文本表示
+    """
+    parts = []
+    
+    if 'camera_maker' in exif_data:
+        parts.append(f"Make: {exif_data['camera_maker']}")
+    
+    if 'camera_model' in exif_data:
+        parts.append(f"Model: {exif_data['camera_model']}")
+    
+    if 'timestamp' in exif_data:
+        parts.append(f"DateTime: {exif_data['timestamp']}")
+    
+    if 'iso' in exif_data:
+        parts.append(f"ISO: {exif_data['iso']}")
+    
+    if 'focal_length' in exif_data:
+        parts.append(f"FocalLength: {exif_data['focal_length']}mm")
+    
+    if 'shutter_speed' in exif_data:
+        shutter = exif_data['shutter_speed']
+        parts.append(f"ExposureTime: 1/{int(shutter)}s")
+    
+    if 'aperture' in exif_data:
+        parts.append(f"FNumber: f/{exif_data['aperture']}")
+    
+    if 'lens_model' in exif_data:
+        parts.append(f"Lens: {exif_data['lens_model']}")
+    
+    return " | ".join(parts)
+
+
+def _save_heif(img: np.ndarray, output_path: str, logger: Logger, exif_data: Optional[Dict[str, Any]] = None):
     """保存为 10-bit HEIF 格式"""
     logger.info("    Format: HEIF (10-bit, High Quality)")
     output_image_uint16 = (img * 65535).astype(np.uint16)
@@ -81,7 +229,7 @@ def _save_heif(img: np.ndarray, output_path: str, logger: Logger):
     heif_file.save(output_path, quality=-1, bit_depth=10)
 
 
-def _save_jpeg_or_other(img: np.ndarray, output_path: str, file_ext: str, logger: Logger):
+def _save_jpeg_or_other(img: np.ndarray, output_path: str, file_ext: str, logger: Logger, exif_data: Optional[Dict[str, Any]] = None):
     """保存为 8-bit JPEG 或其他格式"""
     logger.info(f"    Format: {file_ext.upper()} (8-bit High Quality)")
     

--- a/src/raw_alchemy/preview.py
+++ b/src/raw_alchemy/preview.py
@@ -197,7 +197,7 @@ class PreviewWindow:
             try:
                 with rawpy.imread(self.raw_path) as raw:
                     # 提取EXIF
-                    self.exif_data = utils.extract_lens_exif(raw, logger=print)
+                    self.exif_data = utils.extract_lens_exif(raw, logger=print, raw_path=self.raw_path)
                     
                     # 解码RAW - 使用半尺寸解码加快预览速度（速度提升约4倍）
                     prophoto_linear = raw.postprocess(


### PR DESCRIPTION
This pull request extends the usage of pyexiv2 to write more EXIF metadata into the output TIFF files.
However, there are still several unresolved issues observed during testing:
Timestamp writing issues:
Some EXIF timestamp fields are not written or interpreted correctly. The written time values do not always match the expected results when inspected by downstream tools.
Lens correction not applied:
Lens correction for the Tamron 28–75mm G2 does not seem to take effect.
The root cause appears to be that lensfun cannot correctly identify the lens based on the EXIF lens information currently being written, which prevents proper lens profile matching.
These issues indicate that additional adjustments may be required in how EXIF lens metadata and timestamp fields are populated to ensure compatibility with lensfun and related post-processing workflows.