### PR TITLE
Fix TIFF output by resolving incompatible EXIF issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 /.venv/
 /build/
 /src/raw_alchemy.egg-info/
+/src/raw_alchemy_studio.egg-info/
 /dist/
 /src/raw_alchemy/vendor/lensfun
 /src/raw_alchemy/__pycache__
 *.pyd
+*.pyc
 *.so
 *.dylib

--- a/src/raw_alchemy/file_io.py
+++ b/src/raw_alchemy/file_io.py
@@ -21,7 +21,7 @@ def save_image(
 ) -> bool:
     """
     保存图像到指定路径，根据扩展名自动选择格式
-    
+
     Args:
         img: 图像数据 (float32, 0.0-1.0)
         output_path: 输出路径
@@ -29,50 +29,50 @@ def save_image(
         exif_metadata: 完整的元数据字典 {'exif', 'iptc', 'xmp'} (代替之前的 pyexiv2.Image 对象)
         exif_dict: 从 rawpy 提取的 EXIF 数据字典，当 exif_metadata 写入失败或不可用时降级使用
 
-    
+
     Returns:
         bool: 是否保存成功
     """
     if logger is None:
         from .logger import create_logger
         logger = create_logger()
-    
+
     # 确保数据在有效范围内
     np.clip(img, 0.0, 1.0, out=img)
-    
+
     file_ext = os.path.splitext(output_path)[1].lower()
-    
-    # 标记是否已经处理了 EXIF (DNG 内部处理，不需要后续 pyexiv2 介入)
-    exif_handled_internally = False
+
+    # 某些格式不适合用 pyexiv2 写入完整元数据：
+    # - TIFF: 不复制 RAW 的完整 EXIF/IPTC/XMP。RAW 元数据里可能带有
+    #   CFA/DNG 专用标签、MakerNote 偏移、缩略图引用、SubIFD/其他 TIFF 结构标签；
+    #   这些内容移植到新生成的 RGB TIFF 后，可能破坏 IFD 结构，导致 Photoshop
+    #   等严格解析器无法打开。所以 TIFF 仅保留基础 EXIF 的降级写入。
+    # - DNG: 避免完整 EXIF 注入破坏 IFD 结构
+    allow_full_exif_write = True
 
     try:
         if file_ext in ['.tif', '.tiff']:
             _save_tiff(img, output_path, logger)
+            allow_full_exif_write = False
         elif file_ext == '.dng':
             _save_dng(img, output_path, color_matrix, logger)
-            exif_handled_internally = True  # 【重要】DNG 格式已在保存时写入了必要标签
+            allow_full_exif_write = False
         elif file_ext in ['.heic', '.heif']:
             _save_heif(img, output_path, logger)
         else:
             _save_jpeg_or_other(img, output_path, file_ext, logger)
-        
-        # 【修改逻辑】只有非 DNG 格式才使用 pyexiv2 写入 EXIF
-        # 因为 pyexiv2 修改 DNG 会导致 "Multiple IFDs" 结构错误
-        if not exif_handled_internally:
-            exif_written = False
-            if exif_metadata:
-                exif_written = _write_exif(output_path, exif_metadata, logger)
-            
-            # 如果主要 EXIF 写入失败（例如 pyexiv2 兼容性问题），尝试降级写入
-            if not exif_written and exif_dict:
-                logger.info("  ⚠️  Falling back to basic EXIF writing from dictionary...")
-                _write_exif_from_dict(output_path, exif_dict, logger)
-        else:
+
+        exif_written = False
+        if allow_full_exif_write and exif_metadata:
+            exif_written = _write_exif(output_path, exif_metadata, logger)
+
+        # 如果完整 EXIF 不适用或写入失败，则尝试降级写入基础 EXIF
+        if not exif_written and exif_dict:
             _write_exif_from_dict(output_path, exif_dict, logger)
-        
+
         logger.info(f"  ✅ Saved: {output_path}")
         return True
-        
+
     except Exception as e:
         logger.error(f"  ❌ Failed to save file: {e}")
         import traceback
@@ -84,7 +84,7 @@ def _save_tiff(img: np.ndarray, output_path: str, logger: Logger):
     """保存为 16-bit TIFF 格式"""
     logger.info("    Format: TIFF (16-bit, ZLIB Optimized)")
     output_image_uint16 = (img * 65535).astype(np.uint16)
-    
+
     tifffile.imwrite(
         output_path,
         output_image_uint16,
@@ -99,7 +99,7 @@ def _save_heif(img: np.ndarray, output_path: str, logger: Logger):
     """保存为 10-bit HEIF 格式"""
     logger.info("    Format: HEIF (10-bit, High Quality)")
     output_image_uint16 = (img * 65535).astype(np.uint16)
-    
+
     heif_file = pillow_heif.from_bytes(
         mode='RGB;16',
         size=(output_image_uint16.shape[1], output_image_uint16.shape[0]),
@@ -112,15 +112,15 @@ def _save_dng(img: np.ndarray, output_path: str, color_matrix, logger: Logger):
     """保存为 16-bit DNG 格式 (Adobe Digital Negative)"""
     logger.info("    Format: DNG (16-bit, Linear Raw)")
     output_image_uint16 = (img * 65535).astype(np.uint16)
-    
+
     # 34892 = LinearRaw (表示数据是线性的且已去马赛克)
     photometric = 34892
-    
+
     # DNG 基础标签
     dng_version = [1, 4, 0, 0]
     dng_backward_version = [1, 2, 0, 0]
     camera_model = "Raw Alchemy"
-    
+
     # WhiteLevel: 16-bit 满量程
     white_level = (1 << 16) - 1
     black_level = [0, 0, 0] # RGB 三通道的黑电平
@@ -139,7 +139,7 @@ def _save_dng(img: np.ndarray, output_path: str, color_matrix, logger: Logger):
     matrix_rational = []
     for v in matrix_xyz:
         matrix_rational.extend([int(v * 10000), 10000])
-    
+
     calibration_illuminant1 = 21 # D65
 
     # TIFF Data Types (使用整数代码以兼容不同版本的 tifffile)
@@ -156,12 +156,12 @@ def _save_dng(img: np.ndarray, output_path: str, color_matrix, logger: Logger):
     baseline_exposure_offset_value = [0, 1] # 0.0 EV
 
     profile_name = "Linear Flat"
-    
+
     # ProfileToneCurve: 定义一条直线 (0.0->0.0, 1.0->1.0)
     # 这会覆盖 Adobe 默认的强对比曲线
     # 格式: [Input1, Output1, Input2, Output2] (浮点数)
     profile_tone_curve = [0.0, 0.0, 1.0, 1.0]
-    
+
     # ProfileEmbedPolicy: 允许复制和使用此配置
     profile_embed_policy = [0]
 
@@ -173,7 +173,7 @@ def _save_dng(img: np.ndarray, output_path: str, color_matrix, logger: Logger):
     # 注意: Tags 必须按 ID 升序排列
     extratags = [
         (254, TIFF_LONG, 1, 0),                        # NewSubfileType (Main Image)
-        (274, TIFF_SHORT, 1, 1),                       # Orientation (TopLeft) 
+        (274, TIFF_SHORT, 1, 1),                       # Orientation (TopLeft)
         (50706, TIFF_BYTE, 4, dng_version),            # DNGVersion
         (50707, TIFF_BYTE, 4, dng_backward_version),   # DNGBackwardVersion
         (50708, TIFF_ASCII, len(camera_model)+1, camera_model), # UniqueCameraModel
@@ -195,7 +195,7 @@ def _save_dng(img: np.ndarray, output_path: str, color_matrix, logger: Logger):
     # 使用无损压缩以保持图像质量 (虽然用户建议 compression=None，但 dng 通常可以接受无损压缩，先保持基本兼容性)
     # 若要完全匹配用户建议，可移除 comparison
     # 考虑到文件体积，我们仍然不使用 ZLIB 压缩，或者使用 compression=None 确保兼容性
-    
+
     tifffile.imwrite(
         output_path,
         output_image_uint16,
@@ -205,17 +205,17 @@ def _save_dng(img: np.ndarray, output_path: str, color_matrix, logger: Logger):
         planarconfig=1,
         extratags=extratags,
         description="Linear RGB DNG generated by Raw Alchemy",
-        metadata=None 
+        metadata=None
     )
 
 
 def _save_jpeg_or_other(img: np.ndarray, output_path: str, file_ext: str, logger: Logger):
     """保存为 8-bit JPEG 或其他格式"""
     logger.info(f"    Format: {file_ext.upper()} (8-bit High Quality)")
-    
+
     # 转换为 8-bit（img 已经在 save_image 中被 clip 过了）
     output_image_uint8 = (img * 255).astype(np.uint8)
-    
+
     # JPEG 特殊优化参数
     save_params = {}
     if file_ext in ['.jpg', '.jpeg']:
@@ -224,7 +224,7 @@ def _save_jpeg_or_other(img: np.ndarray, output_path: str, file_ext: str, logger
             'subsampling': 2,
             'optimize': True
         }
-    
+
     # 保存时暂时不写入 EXIF，通过 _write_exif 将 EXIF 注入文件
     Image.fromarray(output_image_uint8).save(output_path, **save_params)
 
@@ -245,14 +245,14 @@ def _write_exif(output_path: str, exif_metadata: dict, logger: Logger) -> bool:
         exif_data = exif_metadata.get('exif', {})
         iptc_data = exif_metadata.get('iptc', {})
         xmp_data = exif_metadata.get('xmp', {})
-        
+
         if not exif_data and not iptc_data and not xmp_data:
             logger.info("    ℹ️  No EXIF data provided to write.")
             return False
 
         # 打开输出文件并写入 EXIF 数据
         output_img = pyexiv2.Image(output_path)
-        
+
         # 写入 EXIF 数据，但排除旋转相关标签
         if exif_data:
             # 移除旋转相关的 EXIF 标签
@@ -261,21 +261,21 @@ def _write_exif(output_path: str, exif_metadata: dict, logger: Logger) -> bool:
             for tag in problematic_tags:
                 if tag in exif_data:
                     del exif_data[tag]
-            
+
             output_img.modify_exif(exif_data)
-        
+
         # 写入 IPTC 数据
         if iptc_data:
             output_img.modify_iptc(iptc_data)
-        
+
         # 写入 XMP 数据
         if xmp_data:
             output_img.modify_xmp(xmp_data)
-        
+
         output_img.close()
         logger.info("    ✅ EXIF data written successfully (rotation info excluded)")
         return True
-        
+
     except Exception as e:
         logger.warning(f"    ⚠️  Failed to write full EXIF data: {e}")
         return False
@@ -284,7 +284,7 @@ def _write_exif(output_path: str, exif_metadata: dict, logger: Logger) -> bool:
 def _write_exif_from_dict(output_path: str, exif_dict: dict, logger: Logger):
     """
     从 rawpy 提取的数据字典构造并写入基本 EXIF 标签
-    
+
     Args:
         output_path: 输出文件路径
         exif_dict: 包含相机和镜头信息的字典 (从 utils.extract_lens_exif 返回)
@@ -293,39 +293,39 @@ def _write_exif_from_dict(output_path: str, exif_dict: dict, logger: Logger):
     try:
         # 打开输出文件
         output_img = pyexiv2.Image(output_path)
-        
+
         # 构造基本的 EXIF 数据
         basic_exif = {}
-        
+
         # 相机信息
         if exif_dict.get('camera_maker'):
             basic_exif['Exif.Image.Make'] = exif_dict['camera_maker']
-        
+
         if exif_dict.get('camera_model'):
             basic_exif['Exif.Image.Model'] = exif_dict['camera_model']
-        
+
         # 镜头信息
         if exif_dict.get('lens_model'):
             basic_exif['Exif.Photo.LensModel'] = exif_dict['lens_model']
-        
+
         if exif_dict.get('lens_maker'):
             basic_exif['Exif.Photo.LensMake'] = exif_dict['lens_maker']
-        
+
         # 拍摄参数
         if exif_dict.get('focal_length'):
             # 将浮点数转换为分数格式（例如 50.0 -> "50/1"）
             focal_mm = exif_dict['focal_length']
             basic_exif['Exif.Photo.FocalLength'] = f"{int(focal_mm * 10)}/10"
-        
+
         if exif_dict.get('aperture'):
             # 光圈值（例如 2.8 -> "28/10"）
             aperture = exif_dict['aperture']
             basic_exif['Exif.Photo.FNumber'] = f"{int(aperture * 10)}/10"
-        
+
         # ISO
         if exif_dict.get('iso'):
             basic_exif['Exif.Photo.ISOSpeedRatings'] = str(exif_dict['iso'])
-            
+
         # 曝光时间 (如果是字符串 "1/100" 直接写入，如果是 float 则转换)
         if exif_dict.get('exposure_time'):
             et = exif_dict['exposure_time']
@@ -353,6 +353,6 @@ def _write_exif_from_dict(output_path: str, exif_dict: dict, logger: Logger):
         else:
             output_img.close()
             logger.warning("    ⚠️  No valid EXIF data to write from rawpy")
-        
+
     except Exception as e:
         logger.warning(f"    ⚠️  Failed to write EXIF from dict: {e}")


### PR DESCRIPTION
Current way of writing full EXIF data into TIFF output using `pyexiv2` will break the file structure. The full metadata payload extracted from the RAW file may contain tags not belonging to an RGB TIFF, including: 
* RAW/CFA-specific tags
* DNG-specific tags
* MakerNote blocks with offsets into the original file
* Thumbnail references
* SubIFD-related tags
* Other structural TIFF/IFD-related tags hidden inside `Exif.Image.*`

Image viewers/editors including Windows Photos and Adobe Photoshop can't open such files, or they'll just show a pure black image. This pull request fixes this issue by using basic/degraded EXIF data for TIFF output. It also adds gitignore for python build files.