### PR TITLE
MacOS Studio Fixes

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,6 @@
+# macOS system dependencies for Raw Alchemy Studio
+# Install with: brew bundle
+
+brew "inih"     # required by pyexiv2 (libINIReader, libinih)
+brew "brotli"   # required by pyexiv2 (libbrotlidec)
+brew "gettext"  # required by pyexiv2 (libintl)

--- a/README.md
+++ b/README.md
@@ -75,12 +75,25 @@ For most users, the easiest way to use Raw Alchemy Studio is to download the pre
 
 If you want to install the project from source, you can follow these steps:
 
+**macOS** — install system libraries first:
+
 ```bash
 # Clone the repository
 git clone https://github.com/shenmintao/raw-alchemy.git
 cd raw-alchemy
 
+# Install macOS system dependencies (required by pyexiv2)
+brew bundle
+
 # Install the tool and its dependencies
+pip install .
+```
+
+**Linux / Windows:**
+
+```bash
+git clone https://github.com/shenmintao/raw-alchemy.git
+cd raw-alchemy
 pip install .
 ```
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -75,12 +75,25 @@
 
 如果您希望从源码安装本项目，可以按照以下步骤操作：
 
+**macOS** — 首先安装系统依赖库：
+
 ```bash
 # 克隆本仓库
 git clone https://github.com/shenmintao/raw-alchemy.git
 cd raw-alchemy
 
+# 安装 macOS 系统依赖（pyexiv2 所需）
+brew bundle
+
 # 安装工具及其依赖
+pip install .
+```
+
+**Linux / Windows：**
+
+```bash
+git clone https://github.com/shenmintao/raw-alchemy.git
+cd raw-alchemy
 pip install .
 ```
 

--- a/src/raw_alchemy/main.py
+++ b/src/raw_alchemy/main.py
@@ -1,13 +1,31 @@
 import sys
 import os
+import platform
 from PySide6.QtWidgets import QApplication
 
 from raw_alchemy import i18n
 from raw_alchemy.ui.main_window import MainWindow
 
+
+def _configure_opengl():
+    # macOS defaults to an OpenGL 2.1 legacy context which cannot compile
+    # #version 330 core shaders. Request Core Profile before QApplication so
+    # all surfaces inherit it. Not needed on Windows/Linux where Qt negotiates
+    # a compatible context automatically.
+    if platform.system() == 'Darwin':
+        from PySide6.QtGui import QSurfaceFormat
+        fmt = QSurfaceFormat()
+        fmt.setVersion(3, 3)
+        fmt.setProfile(QSurfaceFormat.OpenGLContextProfile.CoreProfile)
+        QSurfaceFormat.setDefaultFormat(fmt)
+
+
 def main():
     # --- Taichi is initialized on import of math_ops ---
     # No separate cache directory needed (Taichi manages its own cache)
+
+    # Must be called before QApplication to take effect on all surfaces.
+    _configure_opengl()
 
     # 解决部分Windows环境下缩放问题
     os.environ["QT_ENABLE_HIGHDPI_SCALING"] = "1"

--- a/src/raw_alchemy/onnx/denoiser.py
+++ b/src/raw_alchemy/onnx/denoiser.py
@@ -661,8 +661,17 @@ def _make_session_options(ort, *, enable_mem_pattern: bool = False):
     return options
 
 
+def _coreml_cache_dir() -> str:
+    """Return (and create) a persistent directory for CoreML compiled model cache."""
+    import pathlib
+    cache = pathlib.Path.home() / 'Library' / 'Caches' / 'RawAlchemy' / 'coreml'
+    cache.mkdir(parents=True, exist_ok=True)
+    return str(cache)
+
+
 def _configure_providers(providers: list):
     """Attach bounded arena/workspace options to GPU execution providers."""
+    import platform
     configured = []
     gpu_limit = max(1, int(config.ONNX_GPU_MEMORY_LIMIT_MB)) * 1024 * 1024
     for provider in providers:
@@ -679,6 +688,10 @@ def _configure_providers(providers: list):
             }))
         elif provider in ('DmlExecutionProvider', 'ROCMExecutionProvider'):
             configured.append((provider, {'device_id': 0}))
+        elif provider == 'CoreMLExecutionProvider' and platform.system() == 'Darwin':
+            configured.append((provider, {
+                'ModelCacheDirectory': _coreml_cache_dir(),
+            }))
         else:
             configured.append(provider)
     return configured


### PR DESCRIPTION
  ---
  Fix macOS blank image viewport and slow startup

  Two macOS-specific issues fixed:

  - Blank viewport: Qt on macOS defaults to an OpenGL 2.1 legacy context, which silently fails to compile the #version 330 core shaders used by the image viewport. Fixed by requesting OpenGL 3.3 Core Profile via QSurfaceFormat before QApplication is created. Change is
  macOS-only and does not affect Windows or Linux.
  - Slow startup (~45s): CoreML recompiles ONNX models from scratch on every launch. Fixed by passing a ModelCacheDirectory to the CoreML execution provider, storing compiled .mlmodelc files in ~/Library/Caches/RawAlchemy/coreml/. Subsequent launches load from cache in
  under 1 second.

  Also adds a Brewfile documenting the macOS system libraries required by pyexiv2 (inih, brotli, gettext), with brew bundle instructions in both READMEs.

  ---
  中文：

  ---
  修复 macOS 图像预览空白及启动缓慢问题

  本 PR 修复了两个 macOS 专属问题：

  - 图像预览空白：macOS 上 Qt 默认使用 OpenGL 2.1 旧版上下文，导致图像视口所用的 #version 330 core 着色器编译静默失败，画面一片空白。修复方法：在创建 QApplication 之前，通过 QSurfaceFormat 请求 OpenGL 3.3 Core Profile。此改动仅影响 macOS，不影响 Windows 和 Linux。
  - 启动缓慢（约 45 秒）：CoreML 每次启动都会重新编译 ONNX 模型。修复方法：向 CoreML 执行提供程序传入 ModelCacheDirectory，将编译好的 .mlmodelc 文件缓存至 ~/Library/Caches/RawAlchemy/coreml/。后续启动可在 1 秒内完成加载。

  同时新增 Brewfile，记录 pyexiv2 在 macOS 上所需的系统库（inih、brotli、gettext），并在两份 README 中补充了 brew bundle 的安装说明。